### PR TITLE
Adding pre-balance descriptions and transaction chapter

### DIFF
--- a/merge_sections.sh
+++ b/merge_sections.sh
@@ -28,6 +28,11 @@ echo "" >> ../specification.md
 echo "&nbsp; \newpage" >> ../specification.md
 
 echo "" >> ../specification.md
+cat Transaction.md >> ../specification.md
+echo "" >> ../specification.md
+echo "&nbsp; \newpage" >> ../specification.md
+
+echo "" >> ../specification.md
 cat NeoContract.md >> ../specification.md
 echo "" >> ../specification.md
 echo "&nbsp; \newpage" >> ../specification.md

--- a/sections/NeoContract.md
+++ b/sections/NeoContract.md
@@ -1,1 +1,33 @@
 # NeoContract
+
+
+## Payable applications
+
+Payable applications are all applications that are `payable` or pays any `network_fee` or `sys_fee`;
+
+### Balances updates
+
+#### Pre-balances
+
+Pre-balances are updated when transactions enter in the `mempool`, throughout the `verification` process.
+In this sense, `verification` updates pre-balances.
+
+In this sense, when a transaction is relayed, we are ensured that all network fees can be correctly payed.
+
+#### After blocks persists
+
+In the meanwhile, while transaction are being executed, pre-balances are again updated for all `payable transactions` given a parameter defined as `maximum_gas_payable`.
+
+In this sense, Invocation transaction should declare the intention to spend an amount of `X` GAS;
+
+## Appendices
+
+### Native Contracts
+
+#### NEO Native
+
+#### GAS Native
+
+#### SimplePolicy
+
+#### Voting

--- a/sections/Transaction.md
+++ b/sections/Transaction.md
@@ -1,0 +1,14 @@
+# Transactions
+
+## How it works
+
+## Signer and co-signers
+
+## Attaching network and system fees
+
+The fields of the transaction in which this values are attached are:
+
+* system fee is attached as GAS (To be updated)
+* network fee is attached as Sender (To be updated)
+
+As soon as transaction enters in the mempool, these values are updated in the pre-balance.


### PR DESCRIPTION
This specification is a little bit related with https://github.com/neo-project/neo/issues/812

We believe that we need to discuss and finish this specification before completing the `SVM`.

The draft of this specification focus on a pre-balance mechanism, which would make us able to simplify the mechanism that mempool is currently using of re-verifying all transactions after each block persists.